### PR TITLE
filter unlisted interviews in fetch function

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,7 @@ The `formSources.config.js` file allows new paths and server sources to be added
 
 ### Path to server config example
 
-`
-yourPath: {
+`yourPath: {
   path: 'yourPath',
   servers: ['New Server Name', 'Existing Server Name'],
-},
-`
-
-
+},`

--- a/src/data/fetchInterviewData.ts
+++ b/src/data/fetchInterviewData.ts
@@ -20,10 +20,12 @@ export const fetchInterviews = async (path) => {
       const response = await fetch(url.toString());
       const data = await response.json();
       if (data && data.interviews) {
-        const taggedInterviews = data.interviews.map((interview) => ({
-          ...interview,
-          serverUrl: server.url,
-        }));
+        const taggedInterviews = data.interviews
+          .filter((interview) => !interview.metadata.unlisted) // exclude unlisted interviews
+          .map((interview) => ({
+            ...interview,
+            serverUrl: server.url,
+          }));
         allInterviews = allInterviews.concat(taggedInterviews);
       }
     } catch (error) {


### PR DESCRIPTION
Issue: https://github.com/SuffolkLITLab/courtformsonline.org/issues/31

Excludes interviews that have metadata.unlisted properties set to true. 