### PR TITLE
forms detail page basic implementation

### DIFF
--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import Button from 'react-bootstrap/Button';
@@ -16,23 +18,19 @@ const InteractiveForm: React.FC<InteractiveFormProps> = ({
   serverUrl,
 }) => {
   const fullUrl = `${serverUrl}${link}`;
+  const formPageUrl = `/forms/${title.toLowerCase().replace(/ /g, '-')}`;
 
   return (
     <div>
       <div className="form-content">
         <div className="form-text-section">
-          <h2 className="form-subheading">{title}</h2>
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>
-            {metadata.before_you_start}
-          </ReactMarkdown>
-          <br />
+          <Link className="form-link" href={formPageUrl} passHref>
+            <h2 className="form-subheading">{title}</h2>
+          </Link>
           <ReactMarkdown remarkPlugins={[remarkGfm]}>
             {metadata.description}
           </ReactMarkdown>
           <br />
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>
-            {metadata.can_I_use_this_form}
-          </ReactMarkdown>
         </div>
         <div className="form-button-section">
           <Button className="form-start-button" href={fullUrl}>

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import Button from 'react-bootstrap/Button';
+import { toUrlFriendlyString } from '../utils/helpers';
 
 interface InteractiveFormProps {
   title: string;
@@ -18,7 +19,7 @@ const InteractiveForm: React.FC<InteractiveFormProps> = ({
   serverUrl,
 }) => {
   const fullUrl = `${serverUrl}${link}`;
-  const formPageUrl = `/forms/${title.toLowerCase().replace(/ /g, '-')}`;
+  const formPageUrl = `/forms/${toUrlFriendlyString(title)}`;
 
   return (
     <div>

--- a/src/app/forms/[form]/page.tsx
+++ b/src/app/forms/[form]/page.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { fetchInterviews } from '../../../data/fetchInterviewData';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import Button from 'react-bootstrap/Button';
+
+interface PageProps {
+  params: {
+    form: string;
+  };
+}
+
+const Page = async ({ params }: PageProps) => {
+  const { form } = params;
+  const { interviewsByTopic, isError } = await fetchInterviews('');
+
+  if (isError) {
+    return <div>Error loading form details</div>;
+  }
+
+  // Find the form details based on the title converted to the format
+  let formDetails = null;
+  Object.keys(interviewsByTopic).forEach((topic) => {
+    interviewsByTopic[topic].forEach((interview) => {
+      const formattedTitle = interview.title.toLowerCase().replace(/ /g, '-');
+      if (formattedTitle === form) {
+        formDetails = interview;
+      }
+    });
+  });
+
+  console.log(formDetails);
+
+  if (!formDetails) {
+    return <div>Form not found</div>;
+  }
+
+  const startFormUrl = `${formDetails.serverUrl}${formDetails.link}`;
+
+  return (
+    <div className="container my-4">
+      <h1>{formDetails.title}</h1>
+      <h2>Description</h2>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+        {formDetails.metadata.description}
+      </ReactMarkdown>
+      <h2>Can I use this form?</h2>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+        {formDetails.metadata.can_I_use_this_form}
+      </ReactMarkdown>
+      <h2>Before you start:</h2>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+        {formDetails.metadata.before_you_start}
+      </ReactMarkdown>
+      <Button className="form-start-button" href={startFormUrl}>
+        Start Form
+      </Button>
+    </div>
+  );
+};
+
+export default Page;
+
+export async function generateStaticParams() {
+  const { interviewsByTopic } = await fetchInterviews('');
+
+  const params = [];
+  Object.keys(interviewsByTopic).forEach((topic) => {
+    interviewsByTopic[topic].forEach((interview) => {
+      const formattedTitle = interview.title.toLowerCase().replace(/ /g, '-');
+      params.push({ form: formattedTitle });
+    });
+  });
+
+  return params;
+}

--- a/src/app/forms/[form]/page.tsx
+++ b/src/app/forms/[form]/page.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
 import { fetchInterviews } from '../../../data/fetchInterviewData';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import Button from 'react-bootstrap/Button';
+import { toUrlFriendlyString } from '../../utils/helpers';
 
 interface PageProps {
   params: {
@@ -12,7 +12,7 @@ interface PageProps {
 
 const Page = async ({ params }: PageProps) => {
   const { form } = params;
-  const { interviewsByTopic, isError } = await fetchInterviews('');
+  const { interviewsByTopic, isError } = await fetchInterviews('ma');
 
   if (isError) {
     return <div>Error loading form details</div>;
@@ -22,14 +22,12 @@ const Page = async ({ params }: PageProps) => {
   let formDetails = null;
   Object.keys(interviewsByTopic).forEach((topic) => {
     interviewsByTopic[topic].forEach((interview) => {
-      const formattedTitle = interview.title.toLowerCase().replace(/ /g, '-');
+      const formattedTitle = toUrlFriendlyString(interview.title);
       if (formattedTitle === form) {
         formDetails = interview;
       }
     });
   });
-
-  console.log(formDetails);
 
   if (!formDetails) {
     return <div>Form not found</div>;
@@ -62,12 +60,12 @@ const Page = async ({ params }: PageProps) => {
 export default Page;
 
 export async function generateStaticParams() {
-  const { interviewsByTopic } = await fetchInterviews('');
+  const { interviewsByTopic } = await fetchInterviews('ma');
 
   const params = [];
   Object.keys(interviewsByTopic).forEach((topic) => {
     interviewsByTopic[topic].forEach((interview) => {
-      const formattedTitle = interview.title.toLowerCase().replace(/ /g, '-');
+      const formattedTitle = toUrlFriendlyString(interview.title);
       params.push({ form: formattedTitle });
     });
   });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -192,6 +192,10 @@ footer {
   color: #002e60;
 }
 
+.form-link {
+  text-decoration: none;
+  cursor: pointer;
+}
 .form-content {
   display: flex;
   justify-content: space-between;

--- a/src/app/utils/helpers.ts
+++ b/src/app/utils/helpers.ts
@@ -1,0 +1,7 @@
+export const toUrlFriendlyString = (title: string) => {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-') // Replace special characters with hyphens
+    .replace(/(^-|-$)/g, '') // Remove leading and trailing hyphens
+    .replace(/-+/g, '-'); // Replace multiple hyphens with a single hyphen
+};


### PR DESCRIPTION
Issues: 
https://github.com/SuffolkLITLab/courtformsonline.org/issues/43
https://github.com/SuffolkLITLab/courtformsonline.org/issues/15

Added a form detail page and converted form list headers to link to said pages

Headers link to detail page
<img width="1383" alt="image" src="https://github.com/SuffolkLITLab/courtformsonline.org/assets/61624970/ddfb6e66-ab3d-4840-95ae-10b09f7e5864">

Example detail page
<img width="1383" alt="image" src="https://github.com/SuffolkLITLab/courtformsonline.org/assets/61624970/e68433dd-f0ac-489c-afed-575482e8d447">


form urls are configured to be the form title, lower cased and hyphenated.  example url `forms/appeal-or-stay-your-eviction`