### PR TITLE
Fixes <Image> component URLs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const isProd = process.env.NODE_ENV === 'production';
 
 const nextConfig = {
   output: 'export',
+  basePath: '/courtformsonline.org', // For testing
   // basePath: isProd ? '/courtformsonline.org' : '',
   // assetPrefix: isProd ? '/courtformsonline.org' : '',
   images: {

--- a/src/app/components/AffiliatesSection.tsx
+++ b/src/app/components/AffiliatesSection.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Interface } from 'readline';
 import styles from '../css/AffiliatesSection.module.css';
+import nextConfig from '../../../next.config';
 
 interface Affiliate {
   name: string;
@@ -37,7 +38,7 @@ export default function AffiliatesBlock() {
           return (
             <Link href={affiliate.url} className="d-block" key={affiliate.name}>
               <Image
-                src={'affiliates/' + affiliate.filename}
+                src={nextConfig.basePath + '/affiliates/' + affiliate.filename}
                 alt={affiliate.name}
                 className={styles.AffiliateLogo}
                 height={affiliate.height}

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { prefix } from '../../../prefix';
 import styles from '../css/Footer.module.css';
+import nextConfig from '../../../next.config';
 
 export default function Footer() {
   return (
@@ -15,7 +16,7 @@ export default function Footer() {
           <div className="col">
             <a href="https://suffolklitlab.org" className={styles.SuffolkLogo}>
               <Image
-                src="/lit-lab-logo-large.svg"
+                src={nextConfig.basePath + '/lit-lab-logo-large.svg'}
                 alt="Suffolk University Law School Legal Information & Technology Lab logo"
                 className="img-fluid mb-3"
                 width={792}

--- a/src/app/components/HowItWorksSection.tsx
+++ b/src/app/components/HowItWorksSection.tsx
@@ -9,10 +9,10 @@ export default function HowItWorksSection() {
   return (
     <section id="how-it-works-section" className="py-5">
       <div className="container">
-        <h2 className="mb-4 how-it-works-heading">How it works</h2>
+        <h2 className="mb-4 how-it-works-heading">How it Works</h2>
         <div className="row">
           <div className="col-md-4">
-            <div className="d-flex align-items-center justify-content-center how-it-works-step">
+            <div className="d-flex align-items-start justify-content-center how-it-works-step">
               <div
                 className="rounded-circle d-flex align-items-center justify-content-center how-it-works-icon"
                 style={{
@@ -38,7 +38,7 @@ export default function HowItWorksSection() {
             </div>
           </div>
           <div className="col-md-4">
-            <div className="d-flex align-items-center justify-content-center how-it-works-step">
+            <div className="d-flex align-items-start justify-content-center how-it-works-step">
               <div
                 className="rounded-circle d-flex align-items-center justify-content-center how-it-works-icon"
                 style={{
@@ -64,7 +64,7 @@ export default function HowItWorksSection() {
             </div>
           </div>
           <div className="col-md-4">
-            <div className="d-flex align-items-center justify-content-center how-it-works-step">
+            <div className="d-flex align-items-start justify-content-center how-it-works-step">
               <div
                 className="rounded-circle d-flex align-items-center justify-content-center how-it-works-icon"
                 style={{

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -15,7 +15,7 @@ export default function NavigationBar() {
       <div className="container">
         <Link href="/" className="navbar-brand d-flex align-items-center">
           <Image
-            src="lit-lab-torch-inverted.svg"
+            src="/courtformsonline.org/lit-lab-torch-inverted.svg"
             alt="LIT Lab logo"
             className={styles.NavLogo + ' logo-image me-2'}
             height={263.32}

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -15,7 +15,7 @@ export default function NavigationBar() {
       <div className="container">
         <Link href="/" className="navbar-brand d-flex align-items-center">
           <Image
-            src="../../lit-lab-torch-inverted.svg"
+            src="lit-lab-torch-inverted.svg"
             alt="LIT Lab logo"
             className={styles.NavLogo + ' logo-image me-2'}
             height={263.32}

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -5,6 +5,7 @@ import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { faLanguage } from '@fortawesome/free-solid-svg-icons';
 import { prefix } from '../../../prefix';
 import styles from '../css/NavigationBar.module.css';
+import nextConfig from '../../../next.config';
 
 export default function NavigationBar() {
   return (
@@ -15,7 +16,7 @@ export default function NavigationBar() {
       <div className="container">
         <Link href="/" className="navbar-brand d-flex align-items-center">
           <Image
-            src="/courtformsonline.org/lit-lab-torch-inverted.svg"
+            src={nextConfig.basePath + '/lit-lab-torch-inverted.svg'}
             alt="LIT Lab logo"
             className={styles.NavLogo + ' logo-image me-2'}
             height={263.32}

--- a/src/app/components/ThankYou.tsx
+++ b/src/app/components/ThankYou.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Interface } from 'readline';
 import styles from '../css/ThankYou.module.css';
+import nextConfig from '../../../next.config';
 
 interface Organization {
   name: string;
@@ -124,7 +125,7 @@ export default function ThankYou() {
             <div className="col" key={org.name}>
               <Link href={org.url} className="d-block">
                 <Image
-                  src={'partners/' + org.icon}
+                  src={nextConfig.basePath + '/partners/' + org.icon}
                   alt={org.name}
                   height={org.height}
                   width={org.width}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,10 +23,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <div className="body-container">
-          <NavigationBar />
-          {children}
-        </div>
+        <NavigationBar />
+        <div className="body-container">{children}</div>
         <Footer />
       </body>
       <Script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" />


### PR DESCRIPTION
This fixes bugs introduced or carried forward by #67 and #63 (on [line 12 of the NavigationBar component](https://github.com/SuffolkLITLab/courtformsonline.org/pull/63/files#diff-c073d6afa4feef746de13a84d22ee67687ea744de1757ad9ef1f109c4788c0a9), specifically).

Image file URLs that were working on my local environment were broken on the staging site, and vice-versa. I tried various relative paths to get around the problem, which didn't work because the staging site is served from a sub-directory of the domain, **projects.suffolklitlab.org/courtformsonline.org**, while the local environment was served from **localhost:3000** with no subdirectory. So the relative paths were different on local v. staging environments and it was always broken on one or the other.

The [Next.js **basePath** documentation](https://nextjs.org/docs/app/api-reference/next-config-js/basePath#images) led me to the solution. I added the **basePath** property to [**next.config.js**](https://github.com/SuffolkLITLab/courtformsonline.org/blob/main/next.config.js) so that the local and staging environments matched, imported the **NextConfig** object into files containing **\<Image>** components, and inserted the **basePath** variable into the **src** property of the existing **\<Image>** components.

When we change the domain to courtformsonline.org, we will need to update or remove the **basePath** property in **next.config.js** (either will work). The **basePath** import and the **basePath** segment in **\<Image>** component **src** properties can be removed, as well (but will work fine if they are left in place).

I will update the launch checklist (#50) with those steps.