### PR TITLE
Add jurisdiction to canonical form URLs

### DIFF
--- a/src/app/[path]/[topic]/page.tsx
+++ b/src/app/[path]/[topic]/page.tsx
@@ -1,3 +1,4 @@
+// Example: courtformsonline.org/ma/housing
 import { legalTopics } from '../../../config/topics.config';
 import { fetchInterviews } from '../../../data/fetchInterviewData';
 import { formSources } from '../../../config/formSources.config';

--- a/src/app/[path]/[topic]/page.tsx
+++ b/src/app/[path]/[topic]/page.tsx
@@ -42,7 +42,9 @@ const Page = async ({ params }: PageProps) => {
             key={index}
             title={interview.title}
             metadata={interview.metadata}
-            landingPageURL={'/' + path + '/forms/' + toUrlFriendlyString(interview.title)}
+            landingPageURL={
+              '/' + path + '/forms/' + toUrlFriendlyString(interview.title)
+            }
             link={interview.link}
             serverUrl={interview.serverUrl}
           />

--- a/src/app/[path]/[topic]/page.tsx
+++ b/src/app/[path]/[topic]/page.tsx
@@ -2,6 +2,7 @@
 import { legalTopics } from '../../../config/topics.config';
 import { fetchInterviews } from '../../../data/fetchInterviewData';
 import { formSources } from '../../../config/formSources.config';
+import { toUrlFriendlyString } from '../../utils/helpers';
 import Button from 'react-bootstrap/Button';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -41,6 +42,7 @@ const Page = async ({ params }: PageProps) => {
             key={index}
             title={interview.title}
             metadata={interview.metadata}
+            landingPageURL={'/' + path + '/forms/' + toUrlFriendlyString(interview.title)}
             link={interview.link}
             serverUrl={interview.serverUrl}
           />

--- a/src/app/[path]/forms/[form]/page.tsx
+++ b/src/app/[path]/forms/[form]/page.tsx
@@ -1,9 +1,9 @@
-// Example: courtformsonline.org/forms/[form-slug]
-import { fetchInterviews } from '../../../data/fetchInterviewData';
+// Example: courtformsonline.org/ma/form/[form-slug]
+import { fetchInterviews } from '../../../../data/fetchInterviewData';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import Button from 'react-bootstrap/Button';
-import { toUrlFriendlyString } from '../../utils/helpers';
+import { toUrlFriendlyString } from '../../../utils/helpers';
 
 interface PageProps {
   params: {

--- a/src/app/[path]/forms/[form]/page.tsx
+++ b/src/app/[path]/forms/[form]/page.tsx
@@ -1,4 +1,4 @@
-// Example: courtformsonline.org/ma/form/[form-slug]
+// Example: courtformsonline.org/ma/forms/[form-slug]
 import { fetchInterviews } from '../../../../data/fetchInterviewData';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';

--- a/src/app/[path]/forms/page.tsx
+++ b/src/app/[path]/forms/page.tsx
@@ -1,0 +1,66 @@
+// Example: courtformsonline.org/ma/forms
+import { Form } from '../../interfaces/Form';
+import InteractiveForm from '../../components/InteractiveForm';
+import { formSources } from '../../../config/formSources.config';
+
+interface LegalFormsPageProps {
+  forms: Form[];
+}
+
+async function getData() {
+  let allData: Form[] = [];
+
+  // Iterating over an array of server objects
+  for (const server of formSources.docassembleServers) {
+    const url = new URL(server.url); // Access the URL directly from the server object
+    url.pathname = '/list';
+    url.search = 'json=1';
+
+    const res = await fetch(url.toString());
+
+    // Handle errors
+    if (!res.ok) {
+      console.error(`Failed to fetch data from ${server.url}`);
+      continue; // Skip this server and continue with the next one
+    }
+
+    const data = await res.json();
+
+    if (!data.hasOwnProperty('interviews')) {
+      console.error(
+        `Data from ${server.url} does not contain "interviews" key`
+      );
+      continue; // Skip this server and continue with the next one
+    }
+
+    // Include the server name and server URL in the data
+    const interviews = data['interviews'].map((interview: Form) => ({
+      ...interview,
+      serverName: server.name,
+      serverUrl: server.url,
+    }));
+
+    allData = allData.concat(interviews);
+  }
+
+  return allData;
+}
+
+export default async function Page() {
+  const forms = await getData();
+
+  return (
+    <div className="container">
+      <h1 className="form-heading">All Forms</h1>
+      {forms.map((form, index) => (
+        <InteractiveForm
+          key={index}
+          title={form.title}
+          metadata={form.metadata}
+          link={form.link}
+          serverUrl={form.serverUrl}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/[path]/forms/page.tsx
+++ b/src/app/[path]/forms/page.tsx
@@ -1,7 +1,10 @@
 // Example: courtformsonline.org/ma/forms
 import { Form } from '../../interfaces/Form';
 import InteractiveForm from '../../components/InteractiveForm';
-import { pathToServerConfig, formSources } from '../../../config/formSources.config';
+import {
+  pathToServerConfig,
+  formSources,
+} from '../../../config/formSources.config';
 import { toUrlFriendlyString } from '../../utils/helpers';
 
 async function getData() {
@@ -62,7 +65,9 @@ export default async function Page({ params }: PageProps) {
           key={index}
           title={form.title}
           metadata={form.metadata}
-          landingPageURL={'/' + path + '/forms/' + toUrlFriendlyString(form.title)}
+          landingPageURL={
+            '/' + path + '/forms/' + toUrlFriendlyString(form.title)
+          }
           link={form.link}
           serverUrl={form.serverUrl}
         />

--- a/src/app/[path]/forms/page.tsx
+++ b/src/app/[path]/forms/page.tsx
@@ -1,11 +1,8 @@
 // Example: courtformsonline.org/ma/forms
 import { Form } from '../../interfaces/Form';
 import InteractiveForm from '../../components/InteractiveForm';
-import { formSources } from '../../../config/formSources.config';
-
-interface LegalFormsPageProps {
-  forms: Form[];
-}
+import { pathToServerConfig, formSources } from '../../../config/formSources.config';
+import { toUrlFriendlyString } from '../../utils/helpers';
 
 async function getData() {
   let allData: Form[] = [];
@@ -46,17 +43,26 @@ async function getData() {
   return allData;
 }
 
-export default async function Page() {
+interface PageProps {
+  params: {
+    path: string;
+  };
+}
+
+export default async function Page({ params }: PageProps) {
   const forms = await getData();
+  const { path } = params;
+  const server = pathToServerConfig[path].name;
 
   return (
     <div className="container">
-      <h1 className="form-heading">All Forms</h1>
+      <h1 className="form-heading">All {server} Forms</h1>
       {forms.map((form, index) => (
         <InteractiveForm
           key={index}
           title={form.title}
           metadata={form.metadata}
+          landingPageURL={'/' + path + '/forms/' + toUrlFriendlyString(form.title)}
           link={form.link}
           serverUrl={form.serverUrl}
         />

--- a/src/app/[path]/layout.tsx
+++ b/src/app/[path]/layout.tsx
@@ -1,7 +1,8 @@
 import { pathToServerConfig } from '../../config/formSources.config';
 
-// This is only necessary because there is a bug within next that doesnt allow static params to be passed from page to page properly.  This layout only exists to assist in passing said props
-
+// This is only necessary because there is a bug within next that doesnt allow
+// static params to be passed from page to page properly. This layout only exists
+// to assist in passing those params.
 export async function generateStaticParams() {
   return Object.keys(pathToServerConfig).map((key) => ({
     path: key.toLowerCase(),

--- a/src/app/[path]/page.tsx
+++ b/src/app/[path]/page.tsx
@@ -1,3 +1,4 @@
+// Example: courtformsonline.org/ma
 import AffiliatesSection from '../components/AffiliatesSection';
 import HeroSection from '../components/HeroSection';
 import HowItWorksSection from '../components/HowItWorksSection';

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import Button from 'react-bootstrap/Button';
-import { toUrlFriendlyString } from '../utils/helpers';
 
 interface InteractiveFormProps {
   title: string;
   metadata: any;
+  landingPageURL: string;
   link: string;
   serverUrl: string;
 }
@@ -15,17 +15,17 @@ interface InteractiveFormProps {
 const InteractiveForm: React.FC<InteractiveFormProps> = ({
   title,
   metadata,
+  landingPageURL,
   link,
   serverUrl,
 }) => {
   const fullUrl = `${serverUrl}${link}`;
-  const formPageUrl = `/forms/${toUrlFriendlyString(title)}`;
 
   return (
     <div>
       <div className="form-content">
         <div className="form-text-section">
-          <Link className="form-link" href={formPageUrl} passHref>
+          <Link className="form-link" href={landingPageURL} passHref>
             <h2 className="form-subheading">{title}</h2>
           </Link>
           <ReactMarkdown remarkPlugins={[remarkGfm]}>

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -1,14 +1,12 @@
 'use client';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { faLanguage } from '@fortawesome/free-solid-svg-icons';
 import { prefix } from '../../../prefix';
 import styles from '../css/NavigationBar.module.css';
 import nextConfig from '../../../next.config';
-import toUpperCase from 'react';
 
 interface PageProps {
   params: {
@@ -17,7 +15,7 @@ interface PageProps {
 }
 
 export default function NavigationBar({ params }: PageProps) {
-  let { path = '' } = useParams();
+  let { path } = params;
   let abbrev = '';
   if (typeof path === 'string' && path.trim().length > 0) {
     abbrev = ' ' + path.toUpperCase();

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -1,13 +1,23 @@
+'use client';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useParams } from 'next/navigation'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { faLanguage } from '@fortawesome/free-solid-svg-icons';
 import { prefix } from '../../../prefix';
 import styles from '../css/NavigationBar.module.css';
 import nextConfig from '../../../next.config';
+import toUpperCase from 'react';
 
-export default function NavigationBar() {
+interface PageProps {
+  params: {
+    path: string;
+  };
+}
+
+export default function NavigationBar({ params }: PageProps) {
+  const { path = '' } = useParams();
   return (
     <nav
       role="navigation"
@@ -68,8 +78,8 @@ export default function NavigationBar() {
               </ul>
             </li> */}
             <li className="nav-item">
-              <Link href="/forms" className={styles.NavLink}>
-                Forms
+              <Link href={path + '/forms'} className={styles.NavLink}>
+                All{path ? ' ' + path.toUpperCase() : ''} Forms
               </Link>
             </li>
             <li className="nav-item">

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -16,7 +16,7 @@ interface PageProps {
 }
 
 export default function NavigationBar({ params }: PageProps) {
-  const { path } = useParams();
+  const { path = '' } = useParams();
   let abbrev = '';
   let pathSegment = '';
   if (typeof path === 'string' && path.trim().length > 0) {

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -16,10 +16,8 @@ interface PageProps {
   };
 }
 
-
 export default function NavigationBar({ params }: PageProps) {
   let { path = '' } = useParams();
-  console.log(path);
   let abbrev = '';
   if (typeof path === 'string' && path.trim().length > 0) {
     abbrev = ' ' + path.toUpperCase();

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { faLanguage } from '@fortawesome/free-solid-svg-icons';
@@ -15,7 +16,7 @@ interface PageProps {
 }
 
 export default function NavigationBar({ params }: PageProps) {
-  let { path } = params;
+  let { path } = useParams();
   let abbrev = '';
   if (typeof path === 'string' && path.trim().length > 0) {
     abbrev = ' ' + path.toUpperCase();

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useParams } from 'next/navigation'
+import { useParams } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { faLanguage } from '@fortawesome/free-solid-svg-icons';
@@ -18,6 +18,10 @@ interface PageProps {
 
 export default function NavigationBar({ params }: PageProps) {
   const { path = '' } = useParams();
+  let abbrev = '';
+  if (typeof path === 'string' && path.trim().length > 0) {
+    abbrev = ' ' + path.toUpperCase();
+  }
   return (
     <nav
       role="navigation"
@@ -79,7 +83,7 @@ export default function NavigationBar({ params }: PageProps) {
             </li> */}
             <li className="nav-item">
               <Link href={path + '/forms'} className={styles.NavLink}>
-                All{path ? ' ' + path.toUpperCase() : ''} Forms
+                All{abbrev} Forms
               </Link>
             </li>
             <li className="nav-item">

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -16,11 +16,14 @@ interface PageProps {
   };
 }
 
+
 export default function NavigationBar({ params }: PageProps) {
-  const { path = '' } = useParams();
+  let { path = '' } = useParams();
+  console.log(path);
   let abbrev = '';
   if (typeof path === 'string' && path.trim().length > 0) {
     abbrev = ' ' + path.toUpperCase();
+    path = '/' + path;
   }
   return (
     <nav

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -13,7 +13,7 @@ import nextConfig from '../../../next.config';
 
 export default function NavigationBar() {
   const params = useParams();
-  const path = typeof params.path !== 'undefined' ? params.path : false;
+  const path = params && Object.hasOwn(params, 'path') ? params.path : '';
   let pathSegment = '';
   if (path && path.length > 0) pathSegment = '/' + path;
   return (

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -3,26 +3,19 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
-import { faLanguage } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowUpRightFromSquare,
+  faLanguage,
+} from '@fortawesome/free-solid-svg-icons';
 import { prefix } from '../../../prefix';
 import styles from '../css/NavigationBar.module.css';
 import nextConfig from '../../../next.config';
 
-interface PageProps {
-  params: {
-    path: string;
-  };
-}
-
-export default function NavigationBar({ params }: PageProps) {
-  const { path = '' } = useParams();
-  let abbrev = '';
+export default function NavigationBar() {
+  const params = useParams();
+  const path = params.path;
   let pathSegment = '';
-  if (typeof path === 'string' && path.trim().length > 0) {
-    abbrev = ' ' + path.toUpperCase();
-    pathSegment = '/' + path;
-  }
+  if (path && path.length > 0) pathSegment = '/' + path;
   return (
     <nav
       role="navigation"
@@ -84,7 +77,7 @@ export default function NavigationBar({ params }: PageProps) {
             </li> */}
             <li className="nav-item">
               <Link href={pathSegment + '/forms'} className={styles.NavLink}>
-                All{abbrev} Forms
+                All <span className={styles.AllFormsPath}>{path}</span> Forms
               </Link>
             </li>
             <li className="nav-item">

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -16,11 +16,12 @@ interface PageProps {
 }
 
 export default function NavigationBar({ params }: PageProps) {
-  let { path } = useParams();
+  const { path } = useParams();
   let abbrev = '';
+  let pathSegment = '';
   if (typeof path === 'string' && path.trim().length > 0) {
     abbrev = ' ' + path.toUpperCase();
-    path = '/' + path;
+    pathSegment = '/' + path;
   }
   return (
     <nav
@@ -82,7 +83,7 @@ export default function NavigationBar({ params }: PageProps) {
               </ul>
             </li> */}
             <li className="nav-item">
-              <Link href={path + '/forms'} className={styles.NavLink}>
+              <Link href={pathSegment + '/forms'} className={styles.NavLink}>
                 All{abbrev} Forms
               </Link>
             </li>

--- a/src/app/components/NavigationBar.tsx
+++ b/src/app/components/NavigationBar.tsx
@@ -13,7 +13,7 @@ import nextConfig from '../../../next.config';
 
 export default function NavigationBar() {
   const params = useParams();
-  const path = params.path;
+  const path = typeof params.path !== 'undefined' ? params.path : false;
   let pathSegment = '';
   if (path && path.length > 0) pathSegment = '/' + path;
   return (
@@ -77,7 +77,13 @@ export default function NavigationBar() {
             </li> */}
             <li className="nav-item">
               <Link href={pathSegment + '/forms'} className={styles.NavLink}>
-                All <span className={styles.AllFormsPath}>{path}</span> Forms
+                All{' '}
+                {path && path.length > 0 ? (
+                  <span className={styles.AllFormsPath}>{path}</span>
+                ) : (
+                  ' '
+                )}{' '}
+                Forms
               </Link>
             </li>
             <li className="nav-item">

--- a/src/app/components/TopicCard.tsx
+++ b/src/app/components/TopicCard.tsx
@@ -86,7 +86,7 @@ const TopicCard = ({
                       index
                     }
                     className="form-tag text-decoration-none"
-                    href={`/forms/${toUrlFriendlyString(interview.metadata.title)}`}
+                    href={path + '/forms/' + toUrlFriendlyString(interview.metadata.title)}
                   >
                     {interview.metadata.title}
                   </Link>

--- a/src/app/components/TopicCard.tsx
+++ b/src/app/components/TopicCard.tsx
@@ -87,6 +87,7 @@ const TopicCard = ({
                     }
                     className="form-tag text-decoration-none"
                     href={
+                      '/' +
                       path +
                       '/forms/' +
                       toUrlFriendlyString(interview.metadata.title)

--- a/src/app/components/TopicCard.tsx
+++ b/src/app/components/TopicCard.tsx
@@ -86,7 +86,11 @@ const TopicCard = ({
                       index
                     }
                     className="form-tag text-decoration-none"
-                    href={path + '/forms/' + toUrlFriendlyString(interview.metadata.title)}
+                    href={
+                      path +
+                      '/forms/' +
+                      toUrlFriendlyString(interview.metadata.title)
+                    }
                   >
                     {interview.metadata.title}
                   </Link>

--- a/src/app/components/TopicsSection.tsx
+++ b/src/app/components/TopicsSection.tsx
@@ -23,7 +23,7 @@ const TopicsSection = async ({ path, interviews, isError }) => {
   return (
     <section id="topics">
       <div className="container">
-        <h2>Browse court forms by category</h2>
+        <h2>Browse Court Forms by Category</h2>
         {filteredTopics.length > 9 && <ShowAllToggle />}
         <div className="row row-cols-1 row-cols-md-3 g-5 card-container">
           {filteredTopics.map((topic, index) => (

--- a/src/app/css/NavigationBar.module.css
+++ b/src/app/css/NavigationBar.module.css
@@ -20,6 +20,11 @@
   &:not(:hover) {
     text-decoration: none;
   }
+
+}
+
+.AllFormsPath {
+  text-transform: uppercase;
 }
 
 .ExternalLinkIcon {

--- a/src/app/forms/[form]/page.tsx
+++ b/src/app/forms/[form]/page.tsx
@@ -1,3 +1,4 @@
+// Example: courtformsonline.org/forms/[form-slug]
 import { fetchInterviews } from '../../../data/fetchInterviewData';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';

--- a/src/app/forms/page.tsx
+++ b/src/app/forms/page.tsx
@@ -1,7 +1,10 @@
 // Example: courtformsonline.org/forms
 import { Form } from '../interfaces/Form';
 import InteractiveForm from '../components/InteractiveForm';
-import { pathToServerConfig, formSources } from '../../config/formSources.config';
+import {
+  pathToServerConfig,
+  formSources,
+} from '../../config/formSources.config';
 import { toUrlFriendlyString } from '../utils/helpers';
 
 const serverProps = pathToServerConfig;
@@ -62,7 +65,9 @@ export default async function Page(path) {
           key={index}
           title={form.title}
           metadata={form.metadata}
-          landingPageURL={form.serverPath + '/forms/' + toUrlFriendlyString(form.title)}
+          landingPageURL={
+            form.serverPath + '/forms/' + toUrlFriendlyString(form.title)
+          }
           link={form.link}
           serverUrl={form.serverUrl}
         />

--- a/src/app/forms/page.tsx
+++ b/src/app/forms/page.tsx
@@ -1,11 +1,10 @@
 // Example: courtformsonline.org/forms
 import { Form } from '../interfaces/Form';
 import InteractiveForm from '../components/InteractiveForm';
-import { formSources } from '../../config/formSources.config';
+import { pathToServerConfig, formSources } from '../../config/formSources.config';
+import { toUrlFriendlyString } from '../utils/helpers';
 
-interface LegalFormsPageProps {
-  forms: Form[];
-}
+const serverProps = pathToServerConfig;
 
 async function getData() {
   let allData: Form[] = [];
@@ -33,11 +32,17 @@ async function getData() {
       continue; // Skip this server and continue with the next one
     }
 
+    let path = '';
+    for (let key in serverProps) {
+      if (serverProps[key].servers.indexOf(server.name) > -1) path = '/' + key;
+    }
+
     // Include the server name and server URL in the data
     const interviews = data['interviews'].map((interview: Form) => ({
       ...interview,
       serverName: server.name,
       serverUrl: server.url,
+      serverPath: path ? path : '',
     }));
 
     allData = allData.concat(interviews);
@@ -46,7 +51,7 @@ async function getData() {
   return allData;
 }
 
-export default async function Page() {
+export default async function Page(path) {
   const forms = await getData();
 
   return (
@@ -57,6 +62,7 @@ export default async function Page() {
           key={index}
           title={form.title}
           metadata={form.metadata}
+          landingPageURL={form.serverPath + '/forms/' + toUrlFriendlyString(form.title)}
           link={form.link}
           serverUrl={form.serverUrl}
         />

--- a/src/app/forms/page.tsx
+++ b/src/app/forms/page.tsx
@@ -1,3 +1,4 @@
+// Example: courtformsonline.org/forms
 import { Form } from '../interfaces/Form';
 import InteractiveForm from '../components/InteractiveForm';
 import { formSources } from '../../config/formSources.config';

--- a/src/app/interfaces/Form.ts
+++ b/src/app/interfaces/Form.ts
@@ -4,6 +4,8 @@ export interface Form {
   metadata: {
     description: string;
   };
+  landingPageURL: string;
   link: string;
   serverUrl: string;
+  serverPath: string;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,13 @@
-import './globals.css';
 import { Inter } from 'next/font/google';
-import 'bootstrap/dist/css/bootstrap.css';
+import Script from 'next/script';
+
 import NavigationBar from './components/NavigationBar';
 import Footer from './components/Footer';
+
+import 'bootstrap/dist/css/bootstrap.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import '@fontsource/inter/700.css'; // Bold weight
-import Script from 'next/script';
+import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -15,19 +17,22 @@ export const metadata = {
     'Free online interactive court forms from Suffolk University Law School',
 };
 
+interface LayoutParams {
+  params: {
+    path: string;
+  };
+}
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // console.log('params: ' + JSON.stringify(params));
   return (
     <html lang="en">
       <body className={inter.className}>
-        <NavigationBar
-          params={{
-            path: '',
-          }}
-        />
+        <NavigationBar />
         <div className="body-container">{children}</div>
         <Footer />
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <NavigationBar />
+        <NavigationBar
+          params={{
+            path: '',
+          }}
+        />
         <div className="body-container">{children}</div>
         <Footer />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+// Example: courtformsonline.org
 import AffiliatesSection from './components/AffiliatesSection';
 import HeroSection from './components/HeroSection';
 import HowItWorksSection from './components/HowItWorksSection';

--- a/src/config/formSources.config.js
+++ b/src/config/formSources.config.js
@@ -2,6 +2,7 @@ export const pathToServerConfig = {
   ma: {
     path: 'ma',
     servers: ['Suffolk LIT Lab', 'Greater Boston Legal Services'],
+    name: 'Massachusetts',
   },
 };
 

--- a/src/config/formSources.config.js
+++ b/src/config/formSources.config.js
@@ -8,7 +8,7 @@ export const pathToServerConfig = {
 export const formSources = {
   docassembleServers: [
     {
-      key: 'suffolkListLab',
+      key: 'suffolkLITLab',
       url: 'https://apps.suffolklitlab.org',
       name: 'Suffolk LIT Lab',
     },


### PR DESCRIPTION
This updates form URLs so they included the jurisdiction in the path (i.e., `/ma/forms/[form-slug]`).

There are a few other notable changes related to this:

* I added a **.name** property to the **pathToServerConfig** object in [formSources.config.js](https://github.com/SuffolkLITLab/courtformsonline.org/blob/main/src/config/formSources.config.js) we could use the full name of the jurisdiction on its landing page, for example "All Massachusetts Forms" on `/ma/forms`.
* The **All Forms** link in the header changes when a jurisdictions is being displayed. For example, when viewing `/ma`, it shows **All MA Forms** and points to `/ma/forms`.

When we do add non-MA jurisdictions we will want to revisit the UI and navigation. Right now the site is capable of displaying jurisdiction-specific pages, but it could use some clearer navigation to get up and down the tree.

Closes #66