### PR TITLE
Interview page layout

### DIFF
--- a/src/app/[path]/forms/[form]/page.tsx
+++ b/src/app/[path]/forms/[form]/page.tsx
@@ -40,33 +40,35 @@ const Page = async ({ params }: PageProps) => {
 
   return (
     <div className={styles.FormLandingPage + ' container my-5'}>
-      <p className="badge text-bg-secondary fs-6 fw-normal">Guided Interview</p>
+      <p className="badge text-bg-secondary fs-6 fw-normal">Form</p>
       <h1 className="display-5 mb-4">{formDetails.title}</h1>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.description}
       </ReactMarkdown>
-      {
-        (formDetails.metadata.help_page_url || formDetails.metadata.original_form) && 
+      {(formDetails.metadata.help_page_url ||
+        formDetails.metadata.original_form) && (
         <>
-          <p><strong>More information:</strong></p>
+          <p>
+            <strong>More information:</strong>
+          </p>
           <ul>
-            {formDetails.metadata.help_page_url &&
+            {formDetails.metadata.help_page_url && (
               <li>
-                <Link
-                  href={formDetails.metadata.help_page_url}
-                  target="_blank"
-                >{formDetails.metadata.help_page_title}</Link>
-              </li>}
-            {formDetails.metadata.original_form &&
+                <Link href={formDetails.metadata.help_page_url} target="_blank">
+                  {formDetails.metadata.help_page_title}
+                </Link>
+              </li>
+            )}
+            {formDetails.metadata.original_form && (
               <li>
-                <Link
-                  href={formDetails.metadata.original_form}
-                  target="_blank"
-                >Original form</Link>
-              </li>}
+                <Link href={formDetails.metadata.original_form} target="_blank">
+                  Original form
+                </Link>
+              </li>
+            )}
           </ul>
         </>
-      }
+      )}
       <h2 className="mt-4">Can I Use This Interview?</h2>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.can_I_use_this_form}

--- a/src/app/[path]/forms/[form]/page.tsx
+++ b/src/app/[path]/forms/[form]/page.tsx
@@ -1,9 +1,10 @@
 // Example: courtformsonline.org/ma/forms/[form-slug]
-import { fetchInterviews } from '../../../../data/fetchInterviewData';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import Button from 'react-bootstrap/Button';
+import { fetchInterviews } from '../../../../data/fetchInterviewData';
 import { toUrlFriendlyString } from '../../../utils/helpers';
+import styles from '../../../css/FormLangingPage.module.css';
 
 interface PageProps {
   params: {
@@ -37,7 +38,7 @@ const Page = async ({ params }: PageProps) => {
   const startFormUrl = `${formDetails.serverUrl}${formDetails.link}`;
 
   return (
-    <div className="container my-4">
+    <div className={styles.FormLandingPage + ' container my-4'}>
       <h1>{formDetails.title}</h1>
       <h2>Description</h2>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
@@ -51,7 +52,7 @@ const Page = async ({ params }: PageProps) => {
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.before_you_start}
       </ReactMarkdown>
-      <Button className="form-start-button" href={startFormUrl}>
+      <Button className="interview-start-button" href={startFormUrl}>
         Start Form
       </Button>
     </div>

--- a/src/app/[path]/forms/[form]/page.tsx
+++ b/src/app/[path]/forms/[form]/page.tsx
@@ -38,20 +38,21 @@ const Page = async ({ params }: PageProps) => {
   const startFormUrl = `${formDetails.serverUrl}${formDetails.link}`;
 
   return (
-    <div className={styles.FormLandingPage + ' container my-4'}>
-      <h1>{formDetails.title}</h1>
+    <div className={styles.FormLandingPage + ' container my-5'}>
+      <p className="badge text-bg-secondary fs-6 fw-normal">Interview</p>
+      <h1 className="display-5 mb-4">{formDetails.title}</h1>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.description}
       </ReactMarkdown>
-      <h2>Can You Use This Interview?</h2>
+      <h2 className="mt-4">Can I Use This Interview?</h2>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.can_I_use_this_form}
       </ReactMarkdown>
-      <h2>Before You Start</h2>
+      <h2 className="mt-4">Before You Start</h2>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.before_you_start}
       </ReactMarkdown>
-      <Button className="interview-start-button my-3" href={startFormUrl}>
+      <Button className="btn btn-primary btn-lg my-3" href={startFormUrl}>
         Start Interview
       </Button>
     </div>

--- a/src/app/[path]/forms/[form]/page.tsx
+++ b/src/app/[path]/forms/[form]/page.tsx
@@ -1,6 +1,7 @@
 // Example: courtformsonline.org/ma/forms/[form-slug]
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import Link from 'next/link';
 import Button from 'react-bootstrap/Button';
 import { fetchInterviews } from '../../../../data/fetchInterviewData';
 import { toUrlFriendlyString } from '../../../utils/helpers';
@@ -39,11 +40,33 @@ const Page = async ({ params }: PageProps) => {
 
   return (
     <div className={styles.FormLandingPage + ' container my-5'}>
-      <p className="badge text-bg-secondary fs-6 fw-normal">Interview</p>
+      <p className="badge text-bg-secondary fs-6 fw-normal">Guided Interview</p>
       <h1 className="display-5 mb-4">{formDetails.title}</h1>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.description}
       </ReactMarkdown>
+      {
+        (formDetails.metadata.help_page_url || formDetails.metadata.original_form) && 
+        <>
+          <p><strong>More information:</strong></p>
+          <ul>
+            {formDetails.metadata.help_page_url &&
+              <li>
+                <Link
+                  href={formDetails.metadata.help_page_url}
+                  target="_blank"
+                >{formDetails.metadata.help_page_title}</Link>
+              </li>}
+            {formDetails.metadata.original_form &&
+              <li>
+                <Link
+                  href={formDetails.metadata.original_form}
+                  target="_blank"
+                >Original form</Link>
+              </li>}
+          </ul>
+        </>
+      }
       <h2 className="mt-4">Can I Use This Interview?</h2>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.can_I_use_this_form}

--- a/src/app/[path]/forms/[form]/page.tsx
+++ b/src/app/[path]/forms/[form]/page.tsx
@@ -40,20 +40,19 @@ const Page = async ({ params }: PageProps) => {
   return (
     <div className={styles.FormLandingPage + ' container my-4'}>
       <h1>{formDetails.title}</h1>
-      <h2>Description</h2>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.description}
       </ReactMarkdown>
-      <h2>Can I use this form?</h2>
+      <h2>Can You Use This Interview?</h2>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.can_I_use_this_form}
       </ReactMarkdown>
-      <h2>Before you start:</h2>
+      <h2>Before You Start</h2>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {formDetails.metadata.before_you_start}
       </ReactMarkdown>
-      <Button className="interview-start-button" href={startFormUrl}>
-        Start Form
+      <Button className="interview-start-button my-3" href={startFormUrl}>
+        Start Interview
       </Button>
     </div>
   );

--- a/src/app/css/FormLangingPage.module.css
+++ b/src/app/css/FormLangingPage.module.css
@@ -1,0 +1,7 @@
+.FormLandingPage {
+
+  & .interview-start-button {
+    background-color: #002e60;
+    border-color: #002e60;
+  }
+}

--- a/src/app/css/FormLangingPage.module.css
+++ b/src/app/css/FormLangingPage.module.css
@@ -1,4 +1,3 @@
 .FormLandingPage {
   max-width: 60ch;
-
 }

--- a/src/app/css/FormLangingPage.module.css
+++ b/src/app/css/FormLangingPage.module.css
@@ -1,7 +1,4 @@
 .FormLandingPage {
+  max-width: 60ch;
 
-  & .interview-start-button {
-    background-color: #002e60;
-    border-color: #002e60;
-  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -187,23 +187,11 @@
   justify-content: center;
 }
 
-.form-start-button {
-  margin: 2rem;
-  background-color: #002e60;
-  border-color: #002e60;
-}
-
 @font-face {
   font-family: 'Inter';
   src: url('/fonts/Inter-Bold.ttf') format('truetype');
   font-weight: bold;
   font-style: normal;
-}
-
-.form-start-button {
-  margin: 2rem;
-  background-color: #002e60;
-  border-color: #002e60;
 }
 
 h1,


### PR DESCRIPTION
These are cosmetic updates for interview landings pages. (Closes #15.) Here is a summary of the changes:

* Adds spacing around and within the page content
* Adds a "Form" badge above the interview title
* Increases the size of the interview title slightly
* Limits the line width to 60 characters for readability
* Includes links to the help page and source form if they are included in the metadata
* Increases the size of the start button and changes the label to Start Interview (instead of Start Form)