### PR TITLE
Search Console redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,6 +19,26 @@ const nextConfig = {
           'https://assemblyline.suffolklitlab.org/docs/get_started#join-the-community',
         permanent: true,
       },
+      {
+        source: '/ma/forms/courtformsonline-massaccess',
+        destination: '/ma/forms',
+        permanent: true,
+      },
+      {
+        source: '/myforms',
+        destination: '/forms',
+        permanent: true,
+      },
+      {
+        source: '/forms/form_data.csv',
+        destination: '/forms',
+        permanent: true,
+      },
+      {
+        source: '/hackathon/',
+        destination: 'https://suffolklitlab.org/events/',
+        permanent: true,
+      },
     ];
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,12 @@ const nextConfig = {
         destination: '/forms',
         permanent: true,
       },
+      {
+        source: '/(.*)/slack_archive/(.*).html',
+        destination:
+          'https://assemblyline.suffolklitlab.org/docs/get_started#join-the-community',
+        permanent: true,
+      },
     ];
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -5,8 +5,8 @@ const nextConfig = {
     return [
       // Form Explorer PDFs
       {
-        source: '/forms/:slug([a-zA-Z\\d]*.pdf)', // https://courtformsonline.org/forms/6b4ebd487f82f387512ac20da28803db.pdf
-        destination: 'https://formexplorer.suffolklitlab.org/forms/:slug', // https://s3.amazonaws.com/massaccess.suffolklitlab.org/forms/6b4ebd487f82f387512ac20da28803db.pdf
+        source: '/forms/:slug([a-zA-Z\\d]*.pdf)',
+        destination: 'https://formexplorer.suffolklitlab.org/forms/:slug',
         basePath: false,
         permanent: true,
       },

--- a/next.config.js
+++ b/next.config.js
@@ -3,40 +3,19 @@
 const nextConfig = {
   async redirects() {
     return [
+      // Form Explorer PDFs
       {
-        source: '/forms/(.*).pdf',
-        destination: '/forms',
+        source: '/forms/:slug([a-zA-Z\\d]*.pdf)', // https://courtformsonline.org/forms/6b4ebd487f82f387512ac20da28803db.pdf
+        destination: 'https://formexplorer.suffolklitlab.org/forms/:slug', // https://s3.amazonaws.com/massaccess.suffolklitlab.org/forms/6b4ebd487f82f387512ac20da28803db.pdf
+        basePath: false,
         permanent: true,
       },
-      {
-        source: '/pdfs/(.*).pdf',
-        destination: '/forms',
-        permanent: true,
-      },
-      {
-        source: '/(.*)/slack_archive/(.*).html',
-        destination:
-          'https://assemblyline.suffolklitlab.org/docs/get_started#join-the-community',
-        permanent: true,
-      },
-      {
-        source: '/ma/forms/courtformsonline-massaccess',
-        destination: '/ma/forms',
-        permanent: true,
-      },
-      {
-        source: '/myforms',
-        destination: '/forms',
-        permanent: true,
-      },
+      // Form Explorer CSV
       {
         source: '/forms/form_data.csv',
-        destination: '/forms',
-        permanent: true,
-      },
-      {
-        source: '/hackathon/',
-        destination: 'https://suffolklitlab.org/events/',
+        destination:
+          'https://formexplorer.suffolklitlab.org/forms/form_data.csv',
+        basePath: false,
         permanent: true,
       },
     ];

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,19 @@
 /** @type {import('next').NextConfig} */
 
 const nextConfig = {
-  output: 'export',
-  images: {
-    unoptimized: true,
+  async redirects() {
+    return [
+      {
+        source: '/forms/(.*).pdf',
+        destination: '/forms',
+        permanent: true,
+      },
+      {
+        source: '/pdfs/(.*).pdf',
+        destination: '/forms',
+        permanent: true,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
This PR addresses over 2,300 404s resulting from the new Court Forms Online, as reported by Google Search Console. Apparently the old website included PDF templates in the `/forms/` and `/pdfs/` directory. This PR will redirect those URLs to `/forms` (only for URLs that include `.pdf`).

It also includes a regex for URLs containing `/slack_archive/`, and redirects them to the documentation website.

And there are a few specific (non-regex) redirects.

I also removed the line that disabled image optimization, as optimized images seem like a good thing. It works fine locally, so it seems worth trying.