### PR TITLE
Change envelope icon to an inbox icon

### DIFF
--- a/src/app/components/HowItWorksSection.tsx
+++ b/src/app/components/HowItWorksSection.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  faEnvelope,
+  faInbox,
   faMagnifyingGlass,
   faList,
 } from '@fortawesome/free-solid-svg-icons';
@@ -79,7 +79,7 @@ export default function HowItWorksSection() {
                 }}
               >
                 <FontAwesomeIcon
-                  icon={faEnvelope}
+                  icon={faInbox}
                   size="2x"
                   className="text-white"
                 />


### PR DESCRIPTION
This is an extremely minor PR that simply changes the envelope icon in the "How it works" section on the front page to an inbox. I think envelope connotes mail/email, but not e-filing, while an inbox seems closer to filing generally, and can include all the above.