### PR TITLE
Remove redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,25 +1,5 @@
 /** @type {import('next').NextConfig} */
 
-const nextConfig = {
-  async redirects() {
-    return [
-      // Form Explorer PDFs
-      {
-        source: '/forms/:slug([a-zA-Z\\d]*.pdf)',
-        destination: 'https://formexplorer.suffolklitlab.org/forms/:slug',
-        basePath: false,
-        permanent: true,
-      },
-      // Form Explorer CSV
-      {
-        source: '/forms/form_data.csv',
-        destination:
-          'https://formexplorer.suffolklitlab.org/forms/form_data.csv',
-        basePath: false,
-        permanent: true,
-      },
-    ];
-  },
-};
+const nextConfig = {};
 
 module.exports = nextConfig;


### PR DESCRIPTION
Turns out that when using Next.js and deploying as a static export (as we are), [redirects in next.config.js won't work](https://nextjs.org/docs/pages/building-your-application/deploying/static-exports#unsupported-features). This PR simply removes the redirects, which have been implemented at the domain host (Cloudflare), instead.